### PR TITLE
feat: implement first-pass for state events.

### DIFF
--- a/clients/typescript/src/codec.ts
+++ b/clients/typescript/src/codec.ts
@@ -15,6 +15,8 @@ export type BasicModule = ModuleCodec<
     initSql: string;
     authorizer: string;
     materializer: string;
+    stateMaterializer: string;
+    stateInitSql: string;
     queries: {
       name: string;
       sql: string;
@@ -125,3 +127,14 @@ export type StreamSetHandleArgs = {
   handle: string | null;
 };
 export type StreamSetHandleResp = Result<void>;
+
+export type StreamStateEventBatchArgs = {
+  streamDid: Did;
+  events: EventPayload[];
+};
+export type StreamStateEventBatchResp = Result<void>;
+
+export type StreamClearStateArgs = {
+  streamDid: Did;
+};
+export type StreamClearStateResp = Result<void>;

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -16,6 +16,8 @@ import {
   SqlRows,
   StreamCreateArgs,
   StreamCreateResp,
+  StreamClearStateArgs,
+  StreamClearStateResp,
   StreamEventBatchArgs,
   StreamEventBatchResp,
   StreamInfoArgs,
@@ -24,6 +26,8 @@ import {
   StreamQueryResp,
   StreamSetHandleArgs,
   StreamSetHandleResp,
+  StreamStateEventBatchArgs,
+  StreamStateEventBatchResp,
   StreamSubscribeArgs,
   StreamSubscribeNotification,
   StreamSubscribeResp,
@@ -247,6 +251,33 @@ export class LeafClient {
       ),
     );
     const resp: StreamEventBatchResp = decode(fromBinary(data));
+    if ("Err" in resp) {
+      throw new Error(resp.Err);
+    }
+  }
+
+  async sendStateEvents(streamDid: string, events: Uint8Array[]): Promise<void> {
+    const data: Uint8Array = await this.socket.emitWithAck(
+      "stream/state_event_batch",
+      toBinary(
+        encode({
+          streamDid: streamDid as Did,
+          events: events.map((x) => new BytesWrapper(x)),
+        } satisfies StreamStateEventBatchArgs),
+      ),
+    );
+    const resp: StreamStateEventBatchResp = decode(fromBinary(data));
+    if ("Err" in resp) {
+      throw new Error(resp.Err);
+    }
+  }
+
+  async clearState(streamDid: string): Promise<void> {
+    const data: Uint8Array = await this.socket.emitWithAck(
+      "stream/clear_state",
+      toBinary(encode({ streamDid: streamDid as Did } satisfies StreamClearStateArgs)),
+    );
+    const resp: StreamClearStateResp = decode(fromBinary(data));
     if ("Err" in resp) {
       throw new Error(resp.Err);
     }

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -44,7 +44,10 @@
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"esbuild"
-		]
+		],
+		"overrides": {
+			"@muni-town/leaf-client": "link:../clients/typescript"
+		}
 	},
 	"dependencies": {
 		"@atcute/cbor": "^2.2.8",

--- a/explorer/pnpm-lock.yaml
+++ b/explorer/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@muni-town/leaf-client': link:../clients/typescript
+
 importers:
 
   .:
@@ -21,8 +24,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       '@muni-town/leaf-client':
-        specifier: 0.1.0-alpha.16
-        version: 0.1.0-alpha.16
+        specifier: link:../clients/typescript
+        version: link:../clients/typescript
       svelte-codemirror-editor:
         specifier: ^2.1.0
         version: 2.1.0(codemirror@6.0.2)(svelte@5.38.10)
@@ -461,10 +464,6 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@muni-town/leaf-client@0.1.0-alpha.16':
-    resolution: {integrity: sha512-tFYs/Jn+8NG+GBduIboq1gGQZiho9bFTHVEOt2j3GiYSmRbAt1oI4aBi/eklh2SnpdaCxCIgKXAyKkv5lMYKWg==}
-    hasBin: true
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -584,9 +583,6 @@ packages:
     resolution: {integrity: sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==}
     cpu: [x64]
     os: [win32]
-
-  '@socket.io/component-emitter@3.1.2':
-    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -861,9 +857,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  component-emitter@1.3.1:
-    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -911,13 +904,6 @@ packages:
 
   dexie@4.2.0:
     resolution: {integrity: sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==}
-
-  engine.io-client@6.6.4:
-    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
-
-  engine.io-parser@5.2.3:
-    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
-    engines: {node: '>=10.0.0'}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -1279,9 +1265,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  notepack.io@2.2.0:
-    resolution: {integrity: sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==}
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1476,17 +1459,6 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
-  socket.io-client@4.8.3:
-    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
-    engines: {node: '>=10.0.0'}
-
-  socket.io-msgpack-parser@3.0.2:
-    resolution: {integrity: sha512-1e76bJ1PCKi9H+JiYk+S29PBJvknHjQWM7Mtj0hjF2KxDA6b6rQxv3rTsnwBoz/haZOhlCDIMQvPATbqYeuMxg==}
-
-  socket.io-parser@4.2.5:
-    resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
-    engines: {node: '>=10.0.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1650,22 +1622,6 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  xmlhttprequest-ssl@2.1.2:
-    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
-    engines: {node: '>=0.4.0'}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -2067,17 +2023,6 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@muni-town/leaf-client@0.1.0-alpha.16':
-    dependencies:
-      '@atcute/cbor': 2.2.8
-      '@atcute/cid': 2.2.6
-      socket.io-client: 4.8.3
-      socket.io-msgpack-parser: 3.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2154,8 +2099,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.50.1':
     optional: true
-
-  '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -2448,8 +2391,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  component-emitter@1.3.1: {}
-
   concat-map@0.0.1: {}
 
   cookie@0.6.0: {}
@@ -2479,20 +2420,6 @@ snapshots:
   devalue@5.3.2: {}
 
   dexie@4.2.0: {}
-
-  engine.io-client@6.6.4:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.1
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-      xmlhttprequest-ssl: 2.1.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  engine.io-parser@5.2.3: {}
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -2842,8 +2769,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  notepack.io@2.2.0: {}
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2976,29 +2901,6 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
-
-  socket.io-client@4.8.3:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.1
-      engine.io-client: 6.6.4
-      socket.io-parser: 4.2.5
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io-msgpack-parser@3.0.2:
-    dependencies:
-      component-emitter: 1.3.1
-      notepack.io: 2.2.0
-
-  socket.io-parser@4.2.5:
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
 
   source-map-js@1.2.1: {}
 
@@ -3140,10 +3042,6 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
-
-  ws@8.18.3: {}
-
-  xmlhttprequest-ssl@2.1.2: {}
 
   yallist@5.0.0: {}
 

--- a/explorer/src/lib/workers/backendWorker.ts
+++ b/explorer/src/lib/workers/backendWorker.ts
@@ -56,7 +56,7 @@ class Backend {
 	#leafUrl: string | undefined;
 
 	#oauthReady: Promise<void>;
-	#resolveOauthReady: () => void = () => {};
+	#resolveOauthReady: () => void = () => { };
 	get ready() {
 		return state.#oauthReady;
 	}
@@ -223,6 +223,14 @@ function connectMessagePort(port: MessagePortApi) {
 		},
 		async sendEvents(streamDid, events) {
 			await state.leafClient?.sendEvents(streamDid as Did, events);
+		},
+		async sendStateEvents(streamDid, events) {
+			if (!state.leafClient) throw new Error('Leaf not connected');
+			await state.leafClient.sendStateEvents(streamDid as Did, events);
+		},
+		async clearState(streamDid) {
+			if (!state.leafClient) throw new Error('Leaf not connected');
+			await state.leafClient.clearState(streamDid as Did);
 		},
 		async hasModule(moduleCid) {
 			if (!state.leafClient) throw new Error('Leaf not connected');

--- a/explorer/src/lib/workers/index.ts
+++ b/explorer/src/lib/workers/index.ts
@@ -29,13 +29,15 @@ export type BackendInterface = {
 	query(streamDid: string, query: LeafQuery): Promise<SqlRows>;
 	hasModule(moduleCid: string): Promise<boolean>;
 	streamInfo(streamDid: string): Promise<{ moduleCid?: string }>;
-  setHandle(StreamDid: string, handle: string | null): Promise<void>;
+	setHandle(StreamDid: string, handle: string | null): Promise<void>;
 	createStream(moduleCid: string): Promise<{ streamDid: string }>;
 	updateModule(streamDid: string, moduleCid: string): Promise<void>;
 	subscribeEvents(streamDid: string, query: LeafQuery): Promise<string>;
 	unsubscribe(subId: string): Promise<void>;
 	uploadModule(module: BasicModule): Promise<{ moduleCid: string }>;
 	sendEvents(streamDid: string, events: Uint8Array[]): Promise<void>;
+	sendStateEvents(streamDid: string, events: Uint8Array[]): Promise<void>;
+	clearState(streamDid: string): Promise<void>;
 	setLeafUrl(url: string): Promise<void>;
 	/** Adds a new message port connection to the backend that can call the backend interface. */
 	addClient(port: MessagePort): Promise<void>;

--- a/leaf-server/src/streams.rs
+++ b/leaf-server/src/streams.rs
@@ -135,5 +135,14 @@ pub async fn load_module(
         )
         .await?;
 
+    // Attach the state DB to the module DB
+    // SQLite will create the file automatically if it doesn't exist
+    module_db
+        .execute(
+            "attach ? as state",
+            [stream_dir.join("state.db").to_string_lossy().to_string()],
+        )
+        .await?;
+
     Ok((module, module_db))
 }

--- a/leaf-stream-types/src/lib.rs
+++ b/leaf-stream-types/src/lib.rs
@@ -82,6 +82,8 @@ pub struct BasicModuleDef {
     /// Idempodent initialization SQL that will be used to setup the module's SQLite database.
     ///
     /// This may be multiple statements separated by semicolons;
+    ///
+    /// The SQL should be idempotent as it may be executed multiple times.
     pub init_sql: String,
 
     /// SQL statements that will be used to authorize incoming events before they are inserted
@@ -90,6 +92,22 @@ pub struct BasicModuleDef {
 
     /// SQL statements that will be used to materialize an event that has been authorized.
     pub materializer: String,
+
+    /// SQL statements that will be used to materialize state events into the state db.
+    pub state_materializer: String,
+
+    /// Idempodent initialization SQL that will be used to setup the state database.
+    ///
+    /// This may be multiple statements separated by semicolons.
+    ///
+    /// This SQL is executed on the state database (attached as "state") after it is attached
+    /// to the module database. It will be executed:
+    /// - When the stream is first loaded
+    /// - If the state database is reset.
+    ///
+    /// The SQL should be idempotent as it may be executed multiple times.
+    #[serde(default)]
+    pub state_init_sql: String,
 
     /// The list of queries defined by this module.
     ///

--- a/leaf-stream/src/module.rs
+++ b/leaf-stream/src/module.rs
@@ -66,6 +66,20 @@ pub trait LeafModule: Sync + Send {
         module_db: &libsql::Connection,
     ) -> BoxFuture<'_, anyhow::Result<()>>;
 
+    /// Called to initialize the state database.
+    ///
+    /// The state database is attached to the module database as "state".
+    /// This method will be called:
+    /// - When the stream is first loaded
+    /// - If the state database is reset
+    ///
+    /// > **Note:** It is **ilegal** to change the authorizer of `module_db`. That will be
+    /// > handled by the stream.
+    fn init_state_db_schema(
+        &'_ self,
+        module_db: &libsql::Connection,
+    ) -> BoxFuture<'_, anyhow::Result<()>>;
+
     /// Called to materialize a new event
     ///
     /// > **Note:** It is **ilegal** to change the authorizer of the `module_db`. That will be
@@ -74,6 +88,19 @@ pub trait LeafModule: Sync + Send {
         &'_ self,
         module_db: &libsql::Connection,
         event: Event,
+    ) -> BoxFuture<'_, anyhow::Result<()>>;
+
+    /// Called to materialize a new state event
+    ///
+    /// State events are like regular events but are not stored in the stream's event database.
+    /// They are used for stateful data like "last read" markers, theme preferences, etc.
+    ///
+    /// > **Note:** It is **ilegal** to change the authorizer of the `module_db`. That will be
+    /// > handled by the stream.
+    fn materialize_state_event(
+        &'_ self,
+        module_db: &libsql::Connection,
+        event: IncomingEvent,
     ) -> BoxFuture<'_, anyhow::Result<()>>;
 
     /// Called to authorize a new event


### PR DESCRIPTION
State events allow you to send events that are not persisted themselves, but that are allowed to mutate a state using a module materializer.

This is useful for things like tracking unreads or other information that is always changing, but where the latest state is all you are interested in and event log is unnecessary.

The one feature I know of that we don't have that we might need for state events is to trigger automatic updates so you can subscribe to queries that read from the state DB.