### PR TITLE
fix: fix possible SQLite authorization error that could occur in an edge-case.

### DIFF
--- a/leaf-stream/src/lib.rs
+++ b/leaf-stream/src/lib.rs
@@ -554,6 +554,7 @@ impl Stream {
 
         // Handle errors by rolling back the transaction
         if let Err(e) = result {
+            module_db.authorizer(None)?;
             module_db.execute("rollback", ()).await?;
             return Err(e.into());
         } else {


### PR DESCRIPTION
It doesn't seem likely that we would run into an error in this scenario, but it does appear possible and we have seen an unexpected authorization error, so hopefully this fixes that.

In any case, this change doesn't hurt if there are no errors and isn't bad defensive coding.