### PR TITLE
We added optional client-side stream stamps end-to-end (create, storage, info, TS client), ensured legacy compatibility, and added configurable throttling for create/subscribe so the server is safer under load without changing DID authority semantics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ Meri's [notes from first reading the code](https://leaflet.pub/3abc7a5c-0790-4a4
 
 To compile and run locally: `cargo r -- --otel  server -D did:web:localhost`. For testing, you can also pass `--unsafe-auth-token token123`, which enables an authentication bypass, so you don't need a JWT.
 
+
+## Connection throttling for high-risk endpoints
+
+`leaf-server` now applies lightweight per-actor throttling to these socket events:
+
+- `stream/create`
+- `stream/subscribe_events`
+
+Actor identity is derived from authenticated DID when available. Anonymous connections (including local/dev sessions that skip JWTs) are grouped under a per-socket fallback actor key.
+
+When running locally with `--unsafe-auth-token`, requests are attributed to the server DID, so throttling is still enforced and observable in logs/traces.
+
+Self-hosters can tune the limits via CLI flags or env vars:
+
+- `--throttle-window-secs` / `THROTTLE_WINDOW_SECS`
+- `--stream-create-limit-per-window` / `STREAM_CREATE_LIMIT_PER_WINDOW`
+- `--stream-subscribe-limit-per-window` / `STREAM_SUBSCRIBE_LIMIT_PER_WINDOW`
+- `--max-active-subscriptions-per-actor` / `MAX_ACTIVE_SUBSCRIPTIONS_PER_ACTOR`
+
 ## Dockerfile build
 
 The Dockerfile for `leaf-server` uses statically linked C code that is compiled for x86 architectures, which is also what the server is running. On x86 machines we can run `docker build -t leaf-server:x86_64 .`

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ The Dockerfile for `leaf-server` uses statically linked C code that is compiled 
 For local dev on arm64 machines, we can pass in a build arg: `docker build --build-arg TARGET=aarch64-unknown-linux-musl -t leaf-server:arm64 .`
 
 Then in either case we can run it as usual: `docker run -it --rm -p 5530:5530 -v $(pwd)/data:/data leaf-server`
+
+## Protocol compatibility policy
+
+For this iteration of the wire protocol, compatibility is maintained with additive changes only:
+
+- Existing event names remain unchanged (for example `stream/create`, `stream/info`, and existing socket events).
+- Existing required fields keep their current semantics (`streamDid`, `moduleCid`).
+- Any newly introduced fields are additive and optional.
+- No breaking wire changes are introduced in this iteration.

--- a/clients/typescript/src/codec.ts
+++ b/clients/typescript/src/codec.ts
@@ -93,6 +93,7 @@ export type StreamInfoArgs = {
 };
 export type StreamInfoResp = Result<{
   moduleCid?: CidLinkWrapper;
+  clientStamp?: string;
 }>;
 
 export type StreamUpdateModuleArgs = {

--- a/clients/typescript/src/codec.ts
+++ b/clients/typescript/src/codec.ts
@@ -80,9 +80,13 @@ export type ModuleExistsResp = Result<{ moduleExists: boolean }>;
 
 export type StreamCreateArgs = {
   moduleCid: CidLink;
+  clientStamp?: string;
 };
 
-export type StreamCreateResp = Result<{ streamDid: Did }>;
+export type StreamCreateResp = Result<{
+  streamDid: Did;
+  clientStamp?: string;
+}>;
 
 export type StreamInfoArgs = {
   streamDid: Did;

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -188,11 +188,19 @@ export class LeafClient {
     return resp.Ok.moduleExists;
   }
 
-  async createStream(moduleCid: string): Promise<{ streamDid: string }> {
+  async createStream(
+    moduleCid: string,
+    clientStamp?: string,
+  ): Promise<{ streamDid: string; clientStamp?: string }> {
     const data: Uint8Array = await this.socket.emitWithAck(
       "stream/create",
       toBinary(
-        encode({ moduleCid: { $link: moduleCid } } satisfies StreamCreateArgs),
+        encode(
+          {
+            moduleCid: { $link: moduleCid },
+            clientStamp,
+          } satisfies StreamCreateArgs,
+        ),
       ),
     );
     const resp: StreamCreateResp = decode(fromBinary(data));

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -202,7 +202,7 @@ export class LeafClient {
     return resp.Ok;
   }
 
-  async streamInfo(streamDid: string): Promise<{ moduleCid?: string }> {
+  async streamInfo(streamDid: string): Promise<{ moduleCid?: string; clientStamp?: string }> {
     const data: Uint8Array = await this.socket.emitWithAck(
       "stream/info",
       toBinary(
@@ -213,7 +213,7 @@ export class LeafClient {
     if ("Err" in resp) {
       throw new Error(resp.Err);
     }
-    return { moduleCid: resp.Ok.moduleCid?.$link };
+    return { moduleCid: resp.Ok.moduleCid?.$link, clientStamp: resp.Ok.clientStamp };
   }
 
   async updateModule(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- API (`stream/create`): Added optional `clientStamp` request/response field as advisory client metadata. `streamDid` remains the canonical, authoritative stream identifier and DID creation flow is unchanged.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,3 +3,8 @@
 ## Unreleased
 
 - API (`stream/create`): Added optional `clientStamp` request/response field as advisory client metadata. `streamDid` remains the canonical, authoritative stream identifier and DID creation flow is unchanged.
+- API (`stream/info`): Added optional `clientStamp` response field backed by persisted stream metadata.
+- Storage (`streams`): Added nullable `client_stamp` column, migration support for existing databases, and stream info retrieval to preserve backward compatibility for legacy rows.
+- Client compatibility: Added serialization compatibility tests so legacy request/response shapes continue to decode when new optional fields are present.
+- Reliability (`stream/create`, `stream/subscribe_events`): Added per-actor throttling limits, active-subscription caps, and throttle reset/pruning tests to reduce abusive load without changing happy-path behavior.
+- TypeScript client: `LeafClient.createStream` now optionally accepts `clientStamp` and returns it when present.

--- a/leaf-server/src/cli.rs
+++ b/leaf-server/src/cli.rs
@@ -54,6 +54,22 @@ pub struct ServerArgs {
     #[arg(long, env)]
     pub unsafe_auth_token: Option<String>,
 
+    /// Window size for per-actor throttling on high-risk socket endpoints.
+    #[arg(long, env, default_value_t = 30)]
+    pub throttle_window_secs: u64,
+
+    /// Maximum `stream/create` attempts allowed per actor inside one throttle window.
+    #[arg(long, env, default_value_t = 8)]
+    pub stream_create_limit_per_window: u32,
+
+    /// Maximum `stream/subscribe_events` attempts allowed per actor inside one throttle window.
+    #[arg(long, env, default_value_t = 20)]
+    pub stream_subscribe_limit_per_window: u32,
+
+    /// Maximum active `stream/subscribe_events` subscriptions per actor.
+    #[arg(long, env, default_value_t = 64)]
+    pub max_active_subscriptions_per_actor: u32,
+
     #[clap(flatten)]
     pub backup_config: S3BackupConfigArgs,
 }

--- a/leaf-server/src/http/connection.rs
+++ b/leaf-server/src/http/connection.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+    time::{Duration, Instant},
+};
 
 use async_lock::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use futures::future::{Either, select};
@@ -8,9 +12,12 @@ use leaf_stream::{
     types::{IncomingEvent, LeafQuery, LeafSubscribeEventsResponse, ModuleCodec},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use socketioxide::extract::{AckSender, SocketRef, TryData};
 use tokio::sync::oneshot;
 use tracing::{Instrument, Span};
+
+use crate::cli::Command;
 use ulid::Ulid;
 
 fn response<T: Serialize>(v: anyhow::Result<T>) -> bytes::Bytes {
@@ -21,17 +28,226 @@ fn response<T: Serialize>(v: anyhow::Result<T>) -> bytes::Bytes {
 }
 
 use crate::{
+    ARGS,
     did::{create_did, update_did_handle},
     error::LogError,
     storage::STORAGE,
     streams::STREAMS,
 };
 
+#[derive(Clone, Copy)]
+enum ThrottleEndpoint {
+    StreamCreate,
+    StreamSubscribe,
+}
+
+impl ThrottleEndpoint {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::StreamCreate => "stream/create",
+            Self::StreamSubscribe => "stream/subscribe_events",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ThrottleConfig {
+    window: Duration,
+    stream_create_limit: u32,
+    stream_subscribe_limit: u32,
+    max_active_subscriptions: u32,
+}
+
+impl ThrottleConfig {
+    fn from_args() -> Self {
+        let Command::Server(server_args) = &ARGS.command;
+        Self {
+            window: Duration::from_secs(server_args.throttle_window_secs.max(1)),
+            stream_create_limit: server_args.stream_create_limit_per_window.max(1),
+            stream_subscribe_limit: server_args.stream_subscribe_limit_per_window.max(1),
+            max_active_subscriptions: server_args.max_active_subscriptions_per_actor.max(1),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ActorThrottleState {
+    window_started: Option<Instant>,
+    stream_create_attempts: u32,
+    stream_subscribe_attempts: u32,
+    active_subscriptions: u32,
+}
+
+struct ThrottleCheck {
+    allowed: bool,
+    attempts_in_window: u32,
+    limit: u32,
+    active_subscriptions: u32,
+    retry_after: Duration,
+}
+
+#[derive(Default)]
+struct ThrottleStats {
+    limited_requests_total: u64,
+}
+
+struct ConnectionThrottler {
+    config: ThrottleConfig,
+    state: Mutex<HashMap<String, ActorThrottleState>>,
+    stats: Mutex<ThrottleStats>,
+}
+
+impl ConnectionThrottler {
+    fn new(config: ThrottleConfig) -> Self {
+        Self {
+            config,
+            state: Mutex::new(HashMap::new()),
+            stats: Mutex::new(ThrottleStats::default()),
+        }
+    }
+
+    fn prune_stale_actor_state(
+        &self,
+        state: &mut HashMap<String, ActorThrottleState>,
+        now: Instant,
+    ) {
+        let retention = self.config.window.saturating_mul(2);
+        state.retain(|_, actor_state| {
+            actor_state.active_subscriptions > 0
+                || actor_state
+                    .window_started
+                    .is_some_and(|started| now.duration_since(started) < retention)
+        });
+    }
+
+    async fn check_and_record(&self, actor_key: &str, endpoint: ThrottleEndpoint) -> ThrottleCheck {
+        let mut state = self.state.lock().await;
+        let now = Instant::now();
+        self.prune_stale_actor_state(&mut state, now);
+        let actor_state = state.entry(actor_key.to_string()).or_default();
+
+        let window_started = actor_state.window_started.get_or_insert(now);
+        if now.duration_since(*window_started) >= self.config.window {
+            actor_state.window_started = Some(now);
+            actor_state.stream_create_attempts = 0;
+            actor_state.stream_subscribe_attempts = 0;
+        }
+
+        let retry_after = self
+            .config
+            .window
+            .saturating_sub(now.duration_since(actor_state.window_started.unwrap_or(now)));
+
+        let (attempts, limit) = match endpoint {
+            ThrottleEndpoint::StreamCreate => {
+                actor_state.stream_create_attempts =
+                    actor_state.stream_create_attempts.saturating_add(1);
+                (
+                    actor_state.stream_create_attempts,
+                    self.config.stream_create_limit,
+                )
+            }
+            ThrottleEndpoint::StreamSubscribe => {
+                actor_state.stream_subscribe_attempts =
+                    actor_state.stream_subscribe_attempts.saturating_add(1);
+                (
+                    actor_state.stream_subscribe_attempts,
+                    self.config.stream_subscribe_limit,
+                )
+            }
+        };
+
+        let mut allowed = attempts <= limit;
+        if matches!(endpoint, ThrottleEndpoint::StreamSubscribe)
+            && actor_state.active_subscriptions >= self.config.max_active_subscriptions
+        {
+            allowed = false;
+        }
+
+        if !allowed {
+            let mut stats = self.stats.lock().await;
+            stats.limited_requests_total = stats.limited_requests_total.saturating_add(1);
+            tracing::warn!(
+                actor_key,
+                endpoint = endpoint.as_str(),
+                attempts_in_window = attempts,
+                limit,
+                active_subscriptions = actor_state.active_subscriptions,
+                limited_requests_total = stats.limited_requests_total,
+                "Throttled high-risk endpoint"
+            );
+        }
+
+        ThrottleCheck {
+            allowed,
+            attempts_in_window: attempts,
+            limit,
+            active_subscriptions: actor_state.active_subscriptions,
+            retry_after,
+        }
+    }
+
+    async fn inc_active_subscription(&self, actor_key: &str) -> u32 {
+        let mut state = self.state.lock().await;
+        let actor_state = state.entry(actor_key.to_string()).or_default();
+        actor_state.active_subscriptions = actor_state.active_subscriptions.saturating_add(1);
+        actor_state.active_subscriptions
+    }
+
+    async fn dec_active_subscription(&self, actor_key: &str) -> u32 {
+        let mut state = self.state.lock().await;
+        let now = Instant::now();
+        let actor_state = state.entry(actor_key.to_string()).or_default();
+        actor_state.active_subscriptions = actor_state.active_subscriptions.saturating_sub(1);
+        let active = actor_state.active_subscriptions;
+        self.prune_stale_actor_state(&mut state, now);
+        active
+    }
+}
+
+#[cfg(test)]
+impl ConnectionThrottler {
+    async fn actor_state_len(&self) -> usize {
+        self.state.lock().await.len()
+    }
+}
+
+static CONNECTION_THROTTLER: LazyLock<ConnectionThrottler> =
+    LazyLock::new(|| ConnectionThrottler::new(ThrottleConfig::from_args()));
+
+fn actor_key(did: Option<&String>, anonymous_key: &str) -> String {
+    did.cloned().unwrap_or_else(|| anonymous_key.to_string())
+}
+
+fn throttle_error_message(
+    endpoint: ThrottleEndpoint,
+    check: &ThrottleCheck,
+    max_active_subscriptions: u32,
+) -> String {
+    json!({
+        "code": "rate_limited",
+        "endpoint": endpoint.as_str(),
+        "attemptsInWindow": check.attempts_in_window,
+        "limit": check.limit,
+        "activeSubscriptions": check.active_subscriptions,
+        "maxActiveSubscriptions": max_active_subscriptions,
+        "retryAfterMs": check.retry_after.as_millis(),
+    })
+    .to_string()
+}
+
+struct SubscriptionControl {
+    unsubscribe_tx: oneshot::Sender<()>,
+    actor_key: String,
+}
+
 pub fn setup_socket_handlers(socket: &SocketRef, did: Option<String>) {
     let span = Span::current();
 
     let open_streams = Arc::new(RwLock::new(HashMap::new()));
-    let unsubscribers = Arc::new(Mutex::new(HashMap::new()));
+    let unsubscribers: Arc<Mutex<HashMap<Ulid, SubscriptionControl>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let anonymous_actor_key = format!("anonymous:{}", Ulid::new());
 
     let did_ = did.clone();
     let span_ = span.clone();
@@ -82,10 +298,33 @@ pub fn setup_socket_handlers(socket: &SocketRef, did: Option<String>) {
     let span_ = span.clone();
     let did_ = did.clone();
     let open_streams_ = open_streams.clone();
+    let anonymous_actor_key_ = anonymous_actor_key.clone();
     socket.on(
         "stream/create",
         async move |TryData::<bytes::Bytes>(bytes), ack: AckSender| {
             let result = async {
+                let actor_key = actor_key(did_.as_ref(), &anonymous_actor_key_);
+                let check = CONNECTION_THROTTLER
+                    .check_and_record(&actor_key, ThrottleEndpoint::StreamCreate)
+                    .await;
+                tracing::info!(
+                    actor_key,
+                    endpoint = "stream/create",
+                    create_attempts_in_window = check.attempts_in_window,
+                    create_limit = check.limit,
+                    "Recorded stream/create attempt"
+                );
+                if !check.allowed {
+                    anyhow::bail!(
+                        "{}",
+                        throttle_error_message(
+                            ThrottleEndpoint::StreamCreate,
+                            &check,
+                            CONNECTION_THROTTLER.config.max_active_subscriptions,
+                        )
+                    );
+                }
+
                 let Some(did_) = did_ else {
                     anyhow::bail!("Only authenticated users can create_streams");
                 };
@@ -363,10 +602,34 @@ pub fn setup_socket_handlers(socket: &SocketRef, did: Option<String>) {
     let open_streams_ = open_streams.clone();
     let socket_ = socket.clone();
     let unsubscribers_ = unsubscribers.clone();
+    let anonymous_actor_key_ = anonymous_actor_key.clone();
     socket.on(
         "stream/subscribe_events",
         async move |TryData::<bytes::Bytes>(bytes), ack: AckSender| {
             let result = async {
+                let actor_key = actor_key(did_.as_ref(), &anonymous_actor_key_);
+                let check = CONNECTION_THROTTLER
+                    .check_and_record(&actor_key, ThrottleEndpoint::StreamSubscribe)
+                    .await;
+                tracing::info!(
+                    actor_key,
+                    endpoint = "stream/subscribe_events",
+                    subscribe_attempts_in_window = check.attempts_in_window,
+                    subscribe_limit = check.limit,
+                    active_subscriptions = check.active_subscriptions,
+                    "Recorded stream/subscribe_events attempt"
+                );
+                if !check.allowed {
+                    anyhow::bail!(
+                        "{}",
+                        throttle_error_message(
+                            ThrottleEndpoint::StreamSubscribe,
+                            &check,
+                            CONNECTION_THROTTLER.config.max_active_subscriptions,
+                        )
+                    );
+                }
+
                 let StreamSubscribeArgs { stream_did, query } =
                     dasl::drisl::from_slice(&bytes?[..])?;
 
@@ -384,14 +647,25 @@ pub fn setup_socket_handlers(socket: &SocketRef, did: Option<String>) {
 
                 let receiver = stream.subscribe_events(did_.clone(), query).await;
 
+                let (unsubscribe_tx, unsubscribe_rx) = oneshot::channel();
+                unsubscribers_.lock().await.insert(
+                    subscription_id,
+                    SubscriptionControl {
+                        unsubscribe_tx,
+                        actor_key: actor_key.clone(),
+                    },
+                );
+                let active_subscriptions = CONNECTION_THROTTLER
+                    .inc_active_subscription(&actor_key)
+                    .await;
+                tracing::info!(
+                    actor_key,
+                    active_subscriptions,
+                    endpoint = "stream/subscribe_events",
+                    "Active subscription count increased"
+                );
+
                 tokio::spawn(async move {
-                    let (unsubscribe_tx, unsubscribe_rx) = oneshot::channel();
-
-                    unsubscribers_
-                        .lock()
-                        .await
-                        .insert(subscription_id, unsubscribe_tx);
-
                     let mut next_event = Box::pin(receiver.recv());
                     let mut unsubscribe = unsubscribe_rx;
                     while let Either::Left((Ok(event), _)) =
@@ -413,15 +687,36 @@ pub fn setup_socket_handlers(socket: &SocketRef, did: Option<String>) {
                                     )
                                     .map_err(anyhow::Error::from)
                             }) {
-                                // TODO: better error message
                                 tracing::error!("Error sending event, unsubscribing: {e}");
                             }
                         } else if let Some(unsubscriber) =
                             unsubscribers_.lock().await.remove(&subscription_id)
                         {
                             tracing::info!("Client disconnected, canceling subscription");
-                            unsubscriber.send(()).ok();
+                            let active_subscriptions = CONNECTION_THROTTLER
+                                .dec_active_subscription(&unsubscriber.actor_key)
+                                .await;
+                            tracing::info!(
+                                actor_key = unsubscriber.actor_key,
+                                active_subscriptions,
+                                endpoint = "stream/subscribe_events",
+                                "Active subscription count decreased"
+                            );
+                            unsubscriber.unsubscribe_tx.send(()).ok();
                         }
+                    }
+
+                    if let Some(subscription) = unsubscribers_.lock().await.remove(&subscription_id)
+                    {
+                        let active_subscriptions = CONNECTION_THROTTLER
+                            .dec_active_subscription(&subscription.actor_key)
+                            .await;
+                        tracing::info!(
+                            actor_key = subscription.actor_key,
+                            active_subscriptions,
+                            endpoint = "stream/subscribe_events",
+                            "Active subscription count decreased"
+                        );
                     }
                 });
 
@@ -446,7 +741,18 @@ pub fn setup_socket_handlers(socket: &SocketRef, did: Option<String>) {
                     dasl::drisl::from_slice(&bytes?[..])?;
                 let unsubscriber = unsubscribers_.lock().await.remove(&subscription_id);
                 let was_subscribed = unsubscriber.is_some();
-                unsubscriber.map(|x| x.send(()));
+                if let Some(subscription) = unsubscriber {
+                    let active_subscriptions = CONNECTION_THROTTLER
+                        .dec_active_subscription(&subscription.actor_key)
+                        .await;
+                    tracing::info!(
+                        actor_key = subscription.actor_key,
+                        active_subscriptions,
+                        endpoint = "stream/subscribe_events",
+                        "Active subscription count decreased"
+                    );
+                    subscription.unsubscribe_tx.send(()).ok();
+                }
                 anyhow::Ok(StreamUnsubscribeResp { was_subscribed })
             }
             .instrument(tracing::info_span!(parent: span_.clone(), "handle stream/fetch"))
@@ -576,7 +882,10 @@ struct StreamCreateResp {
 
 #[cfg(test)]
 mod tests {
-    use super::{StreamCreateArgs, StreamCreateResp, StreamInfoResp};
+    use super::{
+        ConnectionThrottler, StreamCreateArgs, StreamCreateResp, StreamInfoResp, ThrottleConfig,
+        ThrottleEndpoint,
+    };
     use leaf_stream::{
         atproto_plc::Did,
         dasl::{
@@ -585,6 +894,7 @@ mod tests {
         },
     };
     use serde::{Deserialize, Serialize};
+    use std::time::Duration;
     use ulid::Ulid;
 
     #[derive(Serialize)]
@@ -732,6 +1042,93 @@ mod tests {
         assert_eq!(parsed.module_cid, Some(module_cid));
     }
 
+    #[tokio::test]
+    async fn stream_create_throttle_allows_under_limit() {
+        let throttler = ConnectionThrottler::new(ThrottleConfig {
+            window: Duration::from_millis(200),
+            stream_create_limit: 3,
+            stream_subscribe_limit: 10,
+            max_active_subscriptions: 5,
+        });
+
+        let first = throttler
+            .check_and_record("did:plc:underlimit", ThrottleEndpoint::StreamCreate)
+            .await;
+        let second = throttler
+            .check_and_record("did:plc:underlimit", ThrottleEndpoint::StreamCreate)
+            .await;
+
+        assert!(first.allowed);
+        assert!(second.allowed);
+        assert_eq!(second.attempts_in_window, 2);
+    }
+
+    #[tokio::test]
+    async fn stream_create_throttle_rejects_over_limit() {
+        let throttler = ConnectionThrottler::new(ThrottleConfig {
+            window: Duration::from_millis(200),
+            stream_create_limit: 1,
+            stream_subscribe_limit: 10,
+            max_active_subscriptions: 5,
+        });
+
+        let first = throttler
+            .check_and_record("did:plc:overlimit", ThrottleEndpoint::StreamCreate)
+            .await;
+        let second = throttler
+            .check_and_record("did:plc:overlimit", ThrottleEndpoint::StreamCreate)
+            .await;
+
+        assert!(first.allowed);
+        assert!(!second.allowed);
+        assert_eq!(second.attempts_in_window, 2);
+    }
+
+    #[tokio::test]
+    async fn throttle_prunes_stale_anonymous_actor_entries() {
+        let throttler = ConnectionThrottler::new(ThrottleConfig {
+            window: Duration::from_millis(20),
+            stream_create_limit: 4,
+            stream_subscribe_limit: 4,
+            max_active_subscriptions: 2,
+        });
+
+        let _ = throttler
+            .check_and_record("anonymous:one", ThrottleEndpoint::StreamCreate)
+            .await;
+        tokio::time::sleep(Duration::from_millis(45)).await;
+        let _ = throttler
+            .check_and_record("anonymous:two", ThrottleEndpoint::StreamCreate)
+            .await;
+
+        assert_eq!(throttler.actor_state_len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn stream_create_throttle_resets_after_window_expiry() {
+        let throttler = ConnectionThrottler::new(ThrottleConfig {
+            window: Duration::from_millis(25),
+            stream_create_limit: 1,
+            stream_subscribe_limit: 10,
+            max_active_subscriptions: 5,
+        });
+
+        let first = throttler
+            .check_and_record("did:plc:reset", ThrottleEndpoint::StreamCreate)
+            .await;
+        let second = throttler
+            .check_and_record("did:plc:reset", ThrottleEndpoint::StreamCreate)
+            .await;
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        let third = throttler
+            .check_and_record("did:plc:reset", ThrottleEndpoint::StreamCreate)
+            .await;
+
+        assert!(first.allowed);
+        assert!(!second.allowed);
+        assert!(third.allowed);
+        assert_eq!(third.attempts_in_window, 1);
+    }
     #[test]
     fn stream_create_upgraded_response_is_ignored_by_legacy_client_parser() {
         let stream_did = "did:plc:z72i7hdynmk6r22z27h6tvur"

--- a/leaf-server/src/schema.sql
+++ b/leaf-server/src/schema.sql
@@ -51,6 +51,8 @@ create table if not exists "streams" (
     "did"    text not null primary key references dids(did),
     -- ID of the WASM module needed by this stream, if any
     "module_cid" blob references module_blobs(cid),
+    -- Optional client-side stamp sent when creating a stream
+    "client_stamp" text,
     -- The index of the latest event in the stream
     "latest_event" integer not null
 ) strict;


### PR DESCRIPTION
Hello!

I normally make software for private clients but I've been looking to contribute to open source projects recently. My friend showed me your repo after the news about Discord came out. I hope the below updates help out even a little. 

What we changed, from the original version, is basically a full pass on stream creation metadata, compatibility safety, and server hardening. The first big improvement is that `stream/create` can now accept an optional `clientStamp` and echo it back in the response, while still keeping `streamDid` as the real authority. So clients can attach a stable client side identifier when they create a stream, but the server model and DID authority didn’t get replaced or weakened. That means you get better offline/local first ergonomics without breaking the protocol’s trust model. You can point to the create handler and the request/response structs where that was wired in. 

The second big change is that we didn’t just echo the stamp once and forget it, we added persistence and retrieval. The `streams` schema now includes `client_stamp`, storage writes it during stream creation, and stream/info returns it along with module info. There’s also a migration path so existing DBs can be upgraded safely with `alter table ... add column client_stamp`, and it gracefully tolerates the “already exists” case. Legacy streams continue to work, new streams can store stamp metadata, and clients can fetch that metadata later. 

Third, we specifically protected compatibility (so old clients don’t break). Old create payloads should still deserialize, upgraded responses still deserialize in legacy client shapes, and both stream-info and stream-create compatibility behavior works as expected. 

Fourth, we added reliability controls where your earlier notes flagged risk: `stream/create` and `stream/subscribe_events` now have per-actor throttling, configurable windows/limits, and active-subscription caps. The implementation also prunes stale actor state and tracks active subscription increments/decrements, so it’s not just a naive counter. This directly helps self-hosting stability and abuse resistance (especially under spammy connection/subscription behavior). 

Fifth, on the TypeScript side, we closed the usability gap by making `LeafClient.createStream()` actually accept optional `clientStamp` and return it, instead of only exposing that support at the lower wire-type level. So app developers using the normal TS client API can now use the feature directly. The codec types and the high-level client method are aligned now. 

And finally, changelog was updated with a clear record of what changed: the create/info API extensions, storage migration, compatibility guarantees, throttling, and TS client follow-through.

Thanks for all the cool projects you're working on, I can't wait to see what else you all build and I hope this is helpful!